### PR TITLE
Added proper reference to api_key in the constructor.

### DIFF
--- a/MailChimp.class.php
+++ b/MailChimp.class.php
@@ -22,7 +22,7 @@ class MailChimp
 	function __construct($api_key)
 	{
 		$this->api_key = $api_key;
-		list(, $datacentre) = explode('-', $api_key);
+		list(, $datacentre) = explode('-', $this->api_key);
 		$this->api_endpoint = str_replace('<dc>', $datacentre, $this->api_endpoint);
 	}
 


### PR DESCRIPTION
Instead of accessing the local variable, it's better to access the global one because we already set it in the previous statement.
