### PR TITLE
Set and return curl error in the event that the call was not successful.

### DIFF
--- a/MailChimp.class.php
+++ b/MailChimp.class.php
@@ -66,9 +66,12 @@ class MailChimp
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verify_ssl);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($args));
 		$result = curl_exec($ch);
+		if (!$result) {
+			$error =  curl_error($ch);
+		}
 		curl_close($ch);
 
-		return $result ? json_decode($result, true) : false;
+		return $result ? json_decode($result, true) : $error;
 	}
 
 }


### PR DESCRIPTION
Will not return Mailchimp response, but will alert of improper configuration.
