### PR TITLE
Add support for JSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $MailChimp = new MailChimp('abc123abc123abc123abc123abc123-us1');
 print_r($MailChimp->get('lists'));
 ```
 
-Subscribe someone to a list
+Subscribe someone to a list and an interest group
 
 ```php
 use \DrewM\MailChimp\MailChimp;
@@ -44,6 +44,7 @@ $result = $MailChimp->post('lists/b1234346/members', array(
 				'email_address'     => 'davy@example.com',
 				'status'			=> 'subscribed',
 				'merge_fields'      => array('FNAME'=>'Davy', 'LNAME'=>'Jones'),
+				'interests' 		=> array( '2s3a384h' => true )
 			));
 print_r($result);
 ```

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -66,7 +66,7 @@ class MailChimp
 
         $url = $this->api_endpoint.'/'.$method;
 
-        $json_data = json_encode($args);
+        $json_data = json_encode($args, JSON_FORCE_OBJECT);
 
         if (function_exists('curl_init') && function_exists('curl_setopt')) {
             $ch = curl_init();


### PR DESCRIPTION
I was unable to add the subscribers to interest groups with this api wrapper because `json_encode` converts all array to JSON array even if MailChimp expects an object. Adding this option to the function will help outputting an object rather than an array when a non-associative array is used.
http://php.net/manual/en/function.json-encode.php
http://php.net/manual/en/json.constants.php

**Example:**

```
$MailChimp->post('lists/12a34b56c/members', array(
        'email_address'     => 'peter@example.com',
        'status'            => 'subscribed',
        'merge_fields'      => array( 'FNAME'  => 'Peter'),
        'interests' 		=> array( '56a7896c' => true )
)
```
