### PR TITLE
Add manual example on includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ You will then need to:
 * run ``composer install`` to get these dependencies added to your vendor directory
 * add the autoloader to your application with this line: ``require("vendor/autoload.php")``
 
-Alternatively you can just download the MailChimp.php file and include it manually.
+Alternatively you can just download the MailChimp.php file and include it manually:
+
+```php
+include('./Mailchimp.php'); 
+```
+
 
 Examples
 --------


### PR DESCRIPTION
Just had a student burn a whole bunch of time - turns out he was using `include('Mailchimp.php');` which worked locally, but we needed `include('./Mailchimp.php');` on his server. 

Hopefully this helps someone in the future!