### PR TITLE
Remove JSON_FORCE_OBJECT from json_encode call

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -69,7 +69,7 @@ class MailChimp
     {
         $url = $this->api_endpoint.'/'.$method;
 
-        $json_data = json_encode($args, JSON_FORCE_OBJECT);
+        $json_data = json_encode($args);
 
         if (function_exists('curl_init') && function_exists('curl_setopt')) {
             $ch = curl_init();


### PR DESCRIPTION
This is incorrect behaviour, as all arrays were getting encoded as JSON objects, regardless of their associativity. See #54 