### PR TITLE
PSR-2 Compliance & Minor Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
+.idea
 /vendor
 composer.lock

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Batch.php
+++ b/src/Batch.php
@@ -10,127 +10,130 @@ namespace DrewM\MailChimp;
  */
 class Batch
 {
-	private $MailChimp;
+    private $MailChimp;
 
-	private $operations = array();
-	private $batch_id;
+    private $operations = array();
+    private $batch_id;
 
-	public function __construct(MailChimp $MailChimp, $batch_id=null)
+    public function __construct(MailChimp $MailChimp, $batch_id = null)
     {
         $this->MailChimp = $MailChimp;
-        $this->batch_id  = $batch_id;
+        $this->batch_id = $batch_id;
     }
 
     /**
      * Add an HTTP DELETE request operation to the batch - for deleting data
-     * @param   string 	$id       ID for the operation within the batch
-     * @param   string 	$method   URL of the API request method
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
      * @return  void
      */
     public function delete($id, $method)
     {
-    	$this->queue_operation('DELETE', $id, $method);
+        $this->queue_operation('DELETE', $id, $method);
     }
 
     /**
      * Add an HTTP GET request operation to the batch - for retrieving data
-     * @param   string 	$id   	 ID for the operation within the batch
-     * @param   string 	$method  URL of the API request method
-     * @param   array 	$args    Assoc array of arguments (usually your data)
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
      * @return  void
      */
-    public function get($id, $method, $args=array())
+    public function get($id, $method, $args = array())
     {
-    	$this->queue_operation('GET', $id, $method, $args);
+        $this->queue_operation('GET', $id, $method, $args);
     }
 
     /**
      * Add an HTTP PATCH request operation to the batch - for performing partial updates
-     * @param   string  $id   	 ID for the operation within the batch
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (usually your data)
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
      * @return  void
      */
-    public function patch($id, $method, $args=array())
+    public function patch($id, $method, $args = array())
     {
-    	$this->queue_operation('PATCH', $id, $method, $args);
+        $this->queue_operation('PATCH', $id, $method, $args);
     }
 
     /**
      * Add an HTTP POST request operation to the batch - for creating and updating items
-     * @param   string   $id 	  ID for the operation within the batch
-     * @param   string   $method  URL of the API request method
-     * @param   array    $args    Assoc array of arguments (usually your data)
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
      * @return  void
      */
-    public function post($id, $method, $args=array())
+    public function post($id, $method, $args = array())
     {
-    	$this->queue_operation('POST', $id, $method, $args);
+        $this->queue_operation('POST', $id, $method, $args);
     }
 
     /**
      * Add an HTTP PUT request operation to the batch - for creating new items
-     * @param   string  $id 	 ID for the operation within the batch
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (usually your data)
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
      * @return  void
      */
-    public function put($id, $method, $args=array())
+    public function put($id, $method, $args = array())
     {
-    	$this->queue_operation('PUT', $id, $method, $args);
+        $this->queue_operation('PUT', $id, $method, $args);
     }
 
     /**
      * Execute the batch request
-     * @param int 	$timeout 	Request timeout in seconds (optional)
+     * @param int $timeout Request timeout in seconds (optional)
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function execute($timeout=10)
+    public function execute($timeout = 10)
     {
-    	$req = array('operations' => $this->operations);
+        $req = array('operations' => $this->operations);
 
-    	$result = $this->MailChimp->post('batches', $req, $timeout);
+        $result = $this->MailChimp->post('batches', $req, $timeout);
 
-    	if ($result && isset($result['id'])) {
-    		$this->batch_id = $result['id'];
-    	}
+        if ($result && isset($result['id'])) {
+            $this->batch_id = $result['id'];
+        }
 
-    	return $result;
+        return $result;
     }
 
     /**
-     * Check the status of a batch request. If the current instance of the Batch object 
+     * Check the status of a batch request. If the current instance of the Batch object
      * was used to make the request, the batch_id is already known and is therefore optional.
-     * @param string 	$batch_id	ID of the batch about which to enquire
+     * @param string $batch_id ID of the batch about which to enquire
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function check_status($batch_id=null)
+    public function check_status($batch_id = null)
     {
-    	if ($batch_id===null && $this->batch_id) $batch_id = $this->batch_id;
-    	return $this->MailChimp->get('batches/'.$batch_id);
+        if ($batch_id === null && $this->batch_id) {
+            $batch_id = $this->batch_id;
+        }
+
+        return $this->MailChimp->get('batches/' . $batch_id);
     }
 
     /**
      * Add an operation to the internal queue.
-     * @param   string  $http_verb  GET, POST, PUT, PATCH or DELETE
-     * @param   string  $id 	 	ID for the operation within the batch
-     * @param   string  $method  	URL of the API request method
-     * @param   array   $args    	Assoc array of arguments (usually your data)
+     * @param   string $http_verb GET, POST, PUT, PATCH or DELETE
+     * @param   string $id ID for the operation within the batch
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
      * @return  void
      */
-    private function queue_operation($http_verb, $id, $method, $args=null)
+    private function queue_operation($http_verb, $id, $method, $args = null)
     {
-		$operation = array(
-				'operation_id' => $id,
-				'method'       => $http_verb,
-				'path'         => $method,
-    		);
+        $operation = array(
+            'operation_id' => $id,
+            'method' => $http_verb,
+            'path' => $method,
+        );
 
-		if ($args) {
-			$key = ($http_verb == 'GET' ? 'params' : 'body');
-			$operation[$key] = json_encode($args);
-		}
+        if ($args) {
+            $key = ($http_verb == 'GET' ? 'params' : 'body');
+            $operation[$key] = json_encode($args);
+        }
 
-		$this->operations[] = $operation;
+        $this->operations[] = $operation;
     }
 }

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -13,17 +13,17 @@ namespace DrewM\MailChimp;
 class MailChimp
 {
     private $api_key;
-    private $api_endpoint  = 'https://<dc>.api.mailchimp.com/3.0';
-    
+    private $api_endpoint = 'https://<dc>.api.mailchimp.com/3.0';
+
     /*  SSL Verification
         Read before disabling: 
         http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
     */
-    public  $verify_ssl    = true; 
+    public $verify_ssl = true;
 
-    private $last_error    = '';
+    private $last_error = '';
     private $last_response = array();
-    private $last_request  = array();
+    private $last_request = array();
 
     /**
      * Create a new instance
@@ -33,25 +33,25 @@ class MailChimp
     {
         $this->api_key = $api_key;
 
-        list(, $datacentre)  = explode('-', $this->api_key);
-        $this->api_endpoint  = str_replace('<dc>', $datacentre, $this->api_endpoint);
+        list(, $datacentre) = explode('-', $this->api_key);
+        $this->api_endpoint = str_replace('<dc>', $datacentre, $this->api_endpoint);
 
-        $this->last_response = array('headers'=>null, 'body'=>null);
+        $this->last_response = array('headers' => null, 'body' => null);
     }
 
     /**
      * Create a new instance of a Batch request. Optionally with the ID of an existing batch.
-     * @param string $batch_id  Optional ID of an existing batch, if you need to check its status for example.
+     * @param string $batch_id Optional ID of an existing batch, if you need to check its status for example.
      * @return Batch            New Batch object.
      */
-    public function new_batch($batch_id=null)
+    public function new_batch($batch_id = null)
     {
         return new Batch($this, $batch_id);
     }
 
     /**
      * Convert an email address into a 'subscriber hash' for identifying the subscriber in a method URL
-     * @param   string  $email  The subscriber's email address
+     * @param   string $email The subscriber's email address
      * @return  string          Hashed version of the input
      */
     public function subscriberHash($email)
@@ -66,7 +66,10 @@ class MailChimp
      */
     public function getLastError()
     {
-        if ($this->last_error) return $this->last_error;
+        if ($this->last_error) {
+            return $this->last_error;
+        }
+
         return false;
     }
 
@@ -87,100 +90,102 @@ class MailChimp
     {
         return $this->last_request;
     }
-    
+
     /**
      * Make an HTTP DELETE request - for deleting data
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (if any)
-     * @param   int     $timeout Timeout limit for request in seconds
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (if any)
+     * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function delete($method, $args=array(), $timeout=10)
+    public function delete($method, $args = array(), $timeout = 10)
     {
         return $this->makeRequest('delete', $method, $args, $timeout);
     }
 
     /**
      * Make an HTTP GET request - for retrieving data
-     * @param   string  $method   URL of the API request method
-     * @param   array   $args     Assoc array of arguments (usually your data)
-     * @param   int     $timeout  Timeout limit for request in seconds
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
+     * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function get($method, $args=array(), $timeout=10)
+    public function get($method, $args = array(), $timeout = 10)
     {
         return $this->makeRequest('get', $method, $args, $timeout);
     }
 
     /**
      * Make an HTTP PATCH request - for performing partial updates
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (usually your data)
-     * @param   int     $timeout Timeout limit for request in seconds
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
+     * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function patch($method, $args=array(), $timeout=10)
+    public function patch($method, $args = array(), $timeout = 10)
     {
         return $this->makeRequest('patch', $method, $args, $timeout);
     }
 
     /**
      * Make an HTTP POST request - for creating and updating items
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (usually your data)
-     * @param   int     $timeout Timeout limit for request in seconds
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
+     * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function post($method, $args=array(), $timeout=10)
+    public function post($method, $args = array(), $timeout = 10)
     {
         return $this->makeRequest('post', $method, $args, $timeout);
     }
 
     /**
      * Make an HTTP PUT request - for creating new items
-     * @param   string  $method  URL of the API request method
-     * @param   array   $args    Assoc array of arguments (usually your data)
-     * @param   int     $timeout Timeout limit for request in seconds
+     * @param   string $method URL of the API request method
+     * @param   array $args Assoc array of arguments (usually your data)
+     * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function put($method, $args=array(), $timeout=10)
+    public function put($method, $args = array(), $timeout = 10)
     {
         return $this->makeRequest('put', $method, $args, $timeout);
     }
 
     /**
      * Performs the underlying HTTP request. Not very exciting.
-     * @param  string $http_verb    The HTTP verb to use: get, post, put, patch, delete
-     * @param  string $method       The API method to be called
-     * @param  array  $args         Assoc array of parameters to be passed
+     * @param  string $http_verb The HTTP verb to use: get, post, put, patch, delete
+     * @param  string $method The API method to be called
+     * @param  array $args Assoc array of parameters to be passed
      * @return array|false          Assoc array of decoded result
      * @throws \Exception
      */
-    private function makeRequest($http_verb, $method, $args=array(), $timeout=10)
+    private function makeRequest($http_verb, $method, $args = array(), $timeout = 10)
     {
         if (!function_exists('curl_init') || !function_exists('curl_setopt')) {
             throw new \Exception("cURL support is required, but can't be found.");
         }
 
-        $url = $this->api_endpoint.'/'.$method;
+        $url = $this->api_endpoint . '/' . $method;
 
-        $this->last_error    = '';
-        $response            = array('headers'=>null, 'body'=>null);
+        $this->last_error = '';
+        $response = array('headers' => null, 'body' => null);
         $this->last_response = $response;
 
-        $this->last_request  = array(
-                                'method' => $http_verb,
-                                'path'   => $method,
-                                'url'    => $url,
-                                'body'   => '',
-                                'timeout'=> $timeout,
-                                );
+        $this->last_request = array(
+            'method' => $http_verb,
+            'path' => $method,
+            'url' => $url,
+            'body' => '',
+            'timeout' => $timeout,
+        );
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/vnd.api+json',
-                                                    'Content-Type: application/vnd.api+json',
-                                                    'Authorization: apikey '.$this->api_key));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'Accept: application/vnd.api+json',
+            'Content-Type: application/vnd.api+json',
+            'Authorization: apikey ' . $this->api_key
+        ));
         curl_setopt($ch, CURLOPT_USERAGENT, 'DrewM/MailChimp-API/3.0 (github.com/drewm/mailchimp-api)');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
@@ -189,7 +194,7 @@ class MailChimp
         curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 
-        switch($http_verb) {
+        switch ($http_verb) {
             case 'post':
                 curl_setopt($ch, CURLOPT_POST, true);
                 $this->attachRequestPayload($ch, $args);
@@ -197,7 +202,7 @@ class MailChimp
 
             case 'get':
                 $query = http_build_query($args);
-                curl_setopt($ch, CURLOPT_URL, $url.'?'.$query);
+                curl_setopt($ch, CURLOPT_URL, $url . '?' . $query);
                 break;
 
             case 'delete':
@@ -208,24 +213,24 @@ class MailChimp
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
                 $this->attachRequestPayload($ch, $args);
                 break;
-            
+
             case 'put':
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 $this->attachRequestPayload($ch, $args);
                 break;
         }
 
-        $response['body']    = curl_exec($ch);
+        $response['body'] = curl_exec($ch);
         $response['headers'] = curl_getinfo($ch);
 
         if (isset($response['headers']['request_header'])) {
             $this->last_request['headers'] = $response['headers']['request_header'];
         }
-        
+
         if ($response['body'] === false) {
             $this->last_error = curl_error($ch);
         }
-        
+
         curl_close($ch);
 
         return $this->formatResponse($response);
@@ -233,14 +238,14 @@ class MailChimp
 
     /**
      * Encode the data and attach it to the request
-     * @param   resource  $ch    cURL session handle, used by reference
-     * @param   array     $data  Assoc array of data to attach
+     * @param   resource $ch cURL session handle, used by reference
+     * @param   array $data Assoc array of data to attach
      */
     private function attachRequestPayload(&$ch, $data)
     {
         $encoded = json_encode($data);
         $this->last_request['body'] = $encoded;
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded); 
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded);
     }
 
     /**
@@ -255,11 +260,11 @@ class MailChimp
         if (!empty($response['body'])) {
 
             $d = json_decode($response['body'], true);
-            
-            if (isset($d['status']) && $d['status']!='200' && isset($d['detail'])) {
+
+            if (isset($d['status']) && $d['status'] != '200' && isset($d['detail'])) {
                 $this->last_error = sprintf('%d: %s', $d['status'], $d['detail']);
             }
-            
+
             return $d;
         }
 

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -66,11 +66,7 @@ class MailChimp
      */
     public function getLastError()
     {
-        if ($this->last_error) {
-            return $this->last_error;
-        }
-
-        return false;
+        return $this->last_error ?: false;
     }
 
     /**

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -2,6 +2,8 @@
 
 namespace DrewM\MailChimp;
 
+use Exception;
+
 /**
  * Super-simple, minimum abstraction MailChimp API v3 wrapper
  * MailChimp API v3: http://developer.mailchimp.com
@@ -28,13 +30,18 @@ class MailChimp
     /**
      * Create a new instance
      * @param string $api_key Your MailChimp API key
+     * @throws Exception
      */
     public function __construct($api_key)
     {
         $this->api_key = $api_key;
 
-        list(, $datacentre) = explode('-', $this->api_key);
-        $this->api_endpoint = str_replace('<dc>', $datacentre, $this->api_endpoint);
+        if (false === strpos($this->api_key, '-')) {
+            throw new Exception('Invalid MailChimp API key supplied.');
+        }
+
+        list(, $data_center) = explode('-', $this->api_key);
+        $this->api_endpoint = str_replace('<dc>', $data_center, $this->api_endpoint);
 
         $this->last_response = array('headers' => null, 'body' => null);
     }
@@ -152,13 +159,14 @@ class MailChimp
      * @param  string $http_verb The HTTP verb to use: get, post, put, patch, delete
      * @param  string $method The API method to be called
      * @param  array $args Assoc array of parameters to be passed
-     * @return array|false          Assoc array of decoded result
-     * @throws \Exception
+     * @param int $timeout
+     * @return array|false Assoc array of decoded result
+     * @throws Exception
      */
     private function makeRequest($http_verb, $method, $args = array(), $timeout = 10)
     {
         if (!function_exists('curl_init') || !function_exists('curl_setopt')) {
-            throw new \Exception("cURL support is required, but can't be found.");
+            throw new Exception("cURL support is required, but can't be found.");
         }
 
         $url = $this->api_endpoint . '/' . $method;

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -1,31 +1,32 @@
 <?php
- 
+
 use \DrewM\MailChimp\MailChimp;
-use \DrewM\MailChimp\Batch;
- 
-class BatchTest extends PHPUnit_Framework_TestCase 
+
+class BatchTest extends PHPUnit_Framework_TestCase
 {
 
-	public function setUp()
-	{
-		$env_file_path = __DIR__.'/../';
-		
-		if (file_exists($env_file_path.'.env')) {
-			$dotenv = new Dotenv\Dotenv($env_file_path);
-			$dotenv->load();	
-		}
-	}
+    public function setUp()
+    {
+        $env_file_path = __DIR__ . '/../';
 
-	public function testNewBatch()
-	{
-		$MC_API_KEY = getenv('MC_API_KEY');
+        if (file_exists($env_file_path . '.env')) {
+            $dotenv = new Dotenv\Dotenv($env_file_path);
+            $dotenv->load();
+        }
+    }
 
-		if (!$MC_API_KEY) $this->markTestSkipped('No API key in ENV');
+    public function testNewBatch()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
 
-		$MailChimp = new MailChimp($MC_API_KEY);
-		$Batch = $MailChimp->new_batch();
-		
-		$this->assertInstanceOf('DrewM\MailChimp\Batch', $Batch);		
-	}
+        if (!$MC_API_KEY) {
+            $this->markTestSkipped('No API key in ENV');
+        }
+
+        $MailChimp = new MailChimp($MC_API_KEY);
+        $Batch = $MailChimp->new_batch();
+
+        $this->assertInstanceOf('DrewM\MailChimp\Batch', $Batch);
+    }
 
 }

--- a/tests/ListsTest.php
+++ b/tests/ListsTest.php
@@ -1,30 +1,32 @@
 <?php
- 
+
 use \DrewM\MailChimp\MailChimp;
- 
-class ListsTest extends PHPUnit_Framework_TestCase 
+
+class ListsTest extends PHPUnit_Framework_TestCase
 {
 
-	public function setUp()
-	{
-		$env_file_path = __DIR__.'/../';
-		
-		if (file_exists($env_file_path.'.env')) {
-			$dotenv = new Dotenv\Dotenv($env_file_path);
-			$dotenv->load();	
-		}
-	}
+    public function setUp()
+    {
+        $env_file_path = __DIR__ . '/../';
 
-	public function testGetLists()
-	{
-		$MC_API_KEY = getenv('MC_API_KEY');
+        if (file_exists($env_file_path . '.env')) {
+            $dotenv = new Dotenv\Dotenv($env_file_path);
+            $dotenv->load();
+        }
+    }
 
-		if (!$MC_API_KEY) $this->markTestSkipped('No API key in ENV');
+    public function testGetLists()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
 
-		$MailChimp = new MailChimp($MC_API_KEY);
-		$lists = $MailChimp->get('lists');
-		
-		$this->assertArrayHasKey('lists', $lists);		
-	}
+        if (!$MC_API_KEY) {
+            $this->markTestSkipped('No API key in ENV');
+        }
+
+        $MailChimp = new MailChimp($MC_API_KEY);
+        $lists = $MailChimp->get('lists');
+
+        $this->assertArrayHasKey('lists', $lists);
+    }
 
 }

--- a/tests/MailChimpTest.php
+++ b/tests/MailChimpTest.php
@@ -1,46 +1,55 @@
 <?php
- 
+
 use \DrewM\MailChimp\MailChimp;
- 
-class MailChimpTest extends PHPUnit_Framework_TestCase 
+
+class MailChimpTest extends PHPUnit_Framework_TestCase
 {
 
-	public function setUp()
-	{
-		$env_file_path = __DIR__.'/../';
-		
-		if (file_exists($env_file_path.'.env')) {
-			$dotenv = new Dotenv\Dotenv($env_file_path);
-			$dotenv->load();	
-		}
-		
-	}
+    public function setUp()
+    {
+        $env_file_path = __DIR__ . '/../';
 
-	public function testTestEnvironment()
-	{
-		$MC_API_KEY = getenv('MC_API_KEY');
-		$this->assertNotEmpty($MC_API_KEY, 'No environment variables! Copy .env.example -> .env and fill out your MailChimp account details.');
-	}
+        if (file_exists($env_file_path . '.env')) {
+            $dotenv = new Dotenv\Dotenv($env_file_path);
+            $dotenv->load();
+        }
 
-	public function testInstantiation()
-	{
-		$MC_API_KEY = getenv('MC_API_KEY');
-		if (!$MC_API_KEY) $this->markTestSkipped('No API key in ENV');
-		$MailChimp = new MailChimp($MC_API_KEY);
-		$this->assertInstanceOf('\DrewM\MailChimp\MailChimp', $MailChimp);
-	}
+    }
 
-	public function testSubscriberHash()
-	{
-		$MC_API_KEY = getenv('MC_API_KEY');
-		if (!$MC_API_KEY) $this->markTestSkipped('No API key in ENV');
-		$MailChimp = new MailChimp($MC_API_KEY);
+    public function testTestEnvironment()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
+        $message = 'No environment variables! Copy .env.example -> .env and fill out your MailChimp account details.';
+        $this->assertNotEmpty($MC_API_KEY, $message);
+    }
 
-		$email    = 'Foo@Example.Com';
-		$expected = md5(strtolower($email));
-		$result   = $MailChimp->subscriberHash($email);
+    public function testInstantiation()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
 
-		$this->assertEquals($expected, $result);
-	}
+        if (!$MC_API_KEY) {
+            $this->markTestSkipped('No API key in ENV');
+        }
+
+        $MailChimp = new MailChimp($MC_API_KEY);
+        $this->assertInstanceOf('\DrewM\MailChimp\MailChimp', $MailChimp);
+    }
+
+    public function testSubscriberHash()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
+
+        if (!$MC_API_KEY) {
+            $this->markTestSkipped('No API key in ENV');
+        }
+
+        $MailChimp = new MailChimp($MC_API_KEY);
+
+        $email = 'Foo@Example.Com';
+        $expected = md5(strtolower($email));
+        $result = $MailChimp->subscriberHash($email);
+
+        $this->assertEquals($expected, $result);
+    }
 
 }


### PR DESCRIPTION
Hello this is my fork with PSR-2 compliant formatting and the minor optimizations I have mentioned about in the E-Mail message.

I have noticed one more thing but I am not certain if it has to throw and Exception or not - when invalid API key is supplied, like one with `-` in it. For example, API key with value of `null`. Then the code raises a PHP notice: `Notice: Undefined offset: 1 in /.../vendor/drewm/mailchimp-api/src/MailChimp.php on line 36`. This is due to usage of `list` built-in function, where we explicitly state that we required index *0* and *1*:

```php
list(, $datacentre)  = explode('-', $this->api_key);
```

I would throw an `Exception` like in other parts of the code with *Invalid API key.* message or something like that. What do you think about this point?

Regards,
Lyubo