### PR TITLE
Specify '&' as the separator for http_build_query

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -214,7 +214,7 @@ class MailChimp
                 break;
 
             case 'get':
-                $query = http_build_query($args);
+                $query = http_build_query($args, '', '&');
                 curl_setopt($ch, CURLOPT_URL, $url . '?' . $query);
                 break;
 


### PR DESCRIPTION
I was having weird problems with offset and count not working. I debugged the issue and found that arg_separator.output was set to '&amp;' on the affected system.

By default http_build_query uses arg_separator.output as the argument separator. Hard-coding this value to ampersand will avoid problems on systems that have changed arg_separator.output.