### PR TITLE
Add getApiEndoint function

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -252,6 +252,14 @@ class MailChimp
 
         return $formattedResponse;
     }
+    
+    /**
+     * @return string The url to the API endpoint
+     */
+    public function getApiEndpoint()
+    {
+        return $this->api_endpoint;
+    }
 
     /**
      * Encode the data and attach it to the request


### PR DESCRIPTION
Currently it seems you have to do the conversion from api-key to api-endpoint (which is done in the constructor) manually again to be able to cut the api-endpoint from URL you get in the results from Mailchimp.

```php
list(, $data_center) = explode('-', $this->api_key);
$this->api_endpoint  = str_replace('<dc>', $data_center, $this->api_endpoint);
```

Typical case: I request a List `$mailchimpAPI->get("lists/$listId");` and I get a Object back containing a `_links`-property. I want to call the `interest-categories`-property inside the `links`-Property next, so I have to cut the `https://<dc>.api.mailchimp.com/3.0` (which is what is inside `$api_endpoint`) from that link and then call it again using `$mailchimpAPI->get($theLinkIJustCreated)`.