### PR TITLE
Added `curl_errno()` check to detect timeouts (and other hard curl errors)

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -236,6 +236,12 @@ class MailChimp
         $response['body']    = curl_exec($ch);
         $response['headers'] = curl_getinfo($ch);
 
+        if (curl_errno($ch)) {
+            $this->last_error = sprintf('Curl error occured: %s', curl_error($ch));
+
+            return false;
+        }
+
         if (isset($response['headers']['request_header'])) {
             $this->last_request['headers'] = $response['headers']['request_header'];
         }


### PR DESCRIPTION
I skip calling both `formatResponse()` and `determineSuccess()`, as they cannot handle hard curl errors (such as timeouts).