### PR TITLE
Added support to set a MailChimp object-wide timeout value

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -82,10 +82,10 @@ class Batch
 
     /**
      * Execute the batch request
-     * @param int $timeout Request timeout in seconds (optional)
-     * @return  array|false   Assoc array of API response, decoded from JSON
+     * @param  int|null $timeout Request timeout in seconds, null implies using MailChimp class' default timeout value
+     * @return array|false   Assoc array of API response, decoded from JSON
      */
-    public function execute($timeout = 10)
+    public function execute($timeout = null)
     {
         $req = array('operations' => $this->operations);
 

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -20,6 +20,7 @@ class MailChimp
         http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
     */
     public $verify_ssl = true;
+    public $default_timeout = 10;
 
     private $request_successful = false;
     private $last_error         = '';
@@ -106,10 +107,10 @@ class MailChimp
      * Make an HTTP DELETE request - for deleting data
      * @param   string $method URL of the API request method
      * @param   array $args Assoc array of arguments (if any)
-     * @param   int $timeout Timeout limit for request in seconds
+     * @param   int|null $timeout Timeout limit for request in seconds, null implies using the default timeout value
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function delete($method, $args = array(), $timeout = 10)
+    public function delete($method, $args = array(), $timeout = null)
     {
         return $this->makeRequest('delete', $method, $args, $timeout);
     }
@@ -118,10 +119,10 @@ class MailChimp
      * Make an HTTP GET request - for retrieving data
      * @param   string $method URL of the API request method
      * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     * @param   int|null $timeout Timeout limit for request in seconds, null implies using the default timeout value
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function get($method, $args = array(), $timeout = 10)
+    public function get($method, $args = array(), $timeout = null)
     {
         return $this->makeRequest('get', $method, $args, $timeout);
     }
@@ -130,10 +131,10 @@ class MailChimp
      * Make an HTTP PATCH request - for performing partial updates
      * @param   string $method URL of the API request method
      * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     * @param   int|null $timeout Timeout limit for request in seconds, null implies using the default timeout value
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function patch($method, $args = array(), $timeout = 10)
+    public function patch($method, $args = array(), $timeout = null)
     {
         return $this->makeRequest('patch', $method, $args, $timeout);
     }
@@ -142,10 +143,10 @@ class MailChimp
      * Make an HTTP POST request - for creating and updating items
      * @param   string $method URL of the API request method
      * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     * @param   int|null $timeout Timeout limit for request in seconds, null implies using the default timeout value
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function post($method, $args = array(), $timeout = 10)
+    public function post($method, $args = array(), $timeout = null)
     {
         return $this->makeRequest('post', $method, $args, $timeout);
     }
@@ -154,10 +155,10 @@ class MailChimp
      * Make an HTTP PUT request - for creating new items
      * @param   string $method URL of the API request method
      * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     * @param   int|null $timeout Timeout limit for request in seconds, null implies using the default timeout value
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function put($method, $args = array(), $timeout = 10)
+    public function put($method, $args = array(), $timeout = null)
     {
         return $this->makeRequest('put', $method, $args, $timeout);
     }
@@ -167,15 +168,17 @@ class MailChimp
      * @param  string $http_verb The HTTP verb to use: get, post, put, patch, delete
      * @param  string $method The API method to be called
      * @param  array $args Assoc array of parameters to be passed
-     * @param int $timeout
+     * @param  int|null $timeout
      * @return array|false Assoc array of decoded result
      * @throws \Exception
      */
-    private function makeRequest($http_verb, $method, $args = array(), $timeout = 10)
+    private function makeRequest($http_verb, $method, $args = array(), $timeout = null)
     {
         if (!function_exists('curl_init') || !function_exists('curl_setopt')) {
             throw new \Exception("cURL support is required, but can't be found.");
         }
+
+        $timeout = $timeout === null ? $this->default_timeout : $timeout;
 
         $url = $this->api_endpoint . '/' . $method;
 


### PR DESCRIPTION
A backwards compatible addition of an object-wide default timeout value.