### PR TITLE
Passed curl errors along to the user

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -309,7 +309,9 @@ class MailChimp
             return false;
         }
 
-        $this->last_error = 'Unknown error, call getLastResponse() to find out what happened.';
+        // The original error is appended so that curl errors are communicated to the user.
+        // An example of one such curl error is #60: SSL certificate problem: unable to get local issuer certificate
+        $this->last_error = 'Unknown error, call getLastResponse() for more details: ' . $this->last_error;
         return false;
     }
 


### PR DESCRIPTION
(they were previously getting swallowed)