### PR TITLE
Expose HTTP headers in the response

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -306,6 +306,11 @@ class MailChimp
     /**
      * Extract all rel => URL pairs from the provided Link header value
      * 
+     * Mailchimp only implements the URI reference and relation type from
+     * RFC 5988, so the value of the header is something like this:
+     * 
+     * 'https://us13.api.mailchimp.com/schema/3.0/Lists/Instance.json; rel="describedBy", <https://us13.admin.mailchimp.com/lists/members/?id=XXXX>; rel="dashboard"'
+     * 
      * @param string $linkHeaderAsString
      * @return array
      */

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -179,10 +179,14 @@ class MailChimp
 
         $url = $this->api_endpoint . '/' . $method;
 
-        $this->last_error         = '';
+        $this->last_error = '';
         $this->request_successful = false;
-        $response                 = array('headers' => null, 'body' => null);
-        $this->last_response      = $response;
+        $response = array(
+            'headers' => null, //array of details from curl_getinfo()
+            'httpHeaders' => null, //array of HTTP headers
+            'body' => null //content of the response
+        );
+        $this->last_response = $response;
 
         $this->last_request = array(
             'method'  => $http_verb,
@@ -201,6 +205,8 @@ class MailChimp
         ));
         curl_setopt($ch, CURLOPT_USERAGENT, 'DrewM/MailChimp-API/3.0 (github.com/drewm/mailchimp-api)');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_VERBOSE, true);
+        curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verify_ssl);
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
@@ -232,16 +238,21 @@ class MailChimp
                 $this->attachRequestPayload($ch, $args);
                 break;
         }
-
-        $response['body']    = curl_exec($ch);
-        $response['headers'] = curl_getinfo($ch);
-
-        if (isset($response['headers']['request_header'])) {
-            $this->last_request['headers'] = $response['headers']['request_header'];
-        }
-
-        if ($response['body'] === false) {
+        
+        $responseContent = curl_exec($ch);
+        
+        if ($responseContent === false) {
             $this->last_error = curl_error($ch);
+        } else {
+            $response['headers'] = curl_getinfo($ch);
+            $headerSize = $response['headers']['header_size'];
+            
+            $response['httpHeaders'] = $this->getHeadersAsArray(substr($responseContent, 0, $headerSize));
+            $response['body'] = substr($responseContent, $headerSize);
+
+            if (isset($response['headers']['request_header'])) {
+                $this->last_request['headers'] = $response['headers']['request_header'];
+            }
         }
 
         curl_close($ch);
@@ -251,6 +262,64 @@ class MailChimp
         $this->determineSuccess($response, $formattedResponse);
 
         return $formattedResponse;
+    }
+
+    /**
+     * Get the HTTP headers as an array of header-name => header-value pairs.
+     * 
+     * The "Link" header is parsed into an associative array based on the
+     * rel names it contains. The original value is available under
+     * the "_raw" key.
+     * 
+     * @param string $headersAsString
+     * @return array
+     */
+    private function getHeadersAsArray($headersAsString)
+    {
+        $headers = [];
+        
+        foreach (explode("\r\n", $headersAsString) as $i => $line) {
+            if ($i === 0) { //HTTP code
+                continue;
+            }
+            
+            $line = trim($line);
+            if (empty($line)) {
+                continue;
+            }
+            
+            list ($key, $value) = explode(': ', $line);
+            
+            if ($key == 'Link') {
+                $value = array_merge(
+                    array('_raw' => $value),
+                    $this->getLinkHeaderAsArray($value)
+                );
+            }
+            
+            $headers[$key] = $value;
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Extract all rel => URL pairs from the provided Link header value
+     * 
+     * @param string $linkHeaderAsString
+     * @return array
+     */
+    private function getLinkHeaderAsArray($linkHeaderAsString)
+    {
+        $urls = [];
+        
+        if (preg_match_all('/<(.*?)>\s*;\s*rel="(.*?)"\s*/', $linkHeaderAsString, $matches)) {
+            foreach ($matches[2] as $i => $relName) {
+                $urls[$relName] = $matches[1][$i];
+            }
+        }
+        
+        return $urls;
     }
 
     /**


### PR DESCRIPTION
This PR gives access to the mailchimp admin URLs which are available in the Link header for certain API endpoints.

For the implementation I left the `headers` key as it was (for backwards compatibility) but as it contains the curl option values from `curl_getinfo()` the key name is a bit misleading.
All the headers from the response are now available under a new `httpHeaders` key. The `Link` header (whenever provided) is parsed into an array of rel-name => url pairs.

This can then be used from the outside as e.g.:
`$url = $MailChimp->getLastResponse()['httpHeaders']['Link']['dashboard'];`