### PR TITLE
Obvious timeout error message.

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -15,6 +15,8 @@ class MailChimp
     private $api_key;
     private $api_endpoint = 'https://<dc>.api.mailchimp.com/3.0';
 
+    const TIMEOUT = 10;
+
     /*  SSL Verification
         Read before disabling:
         http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
@@ -113,7 +115,7 @@ class MailChimp
      * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function delete($method, $args = array(), $timeout = 10)
+    public function delete($method, $args = array(), $timeout = self::TIMEOUT)
     {
         return $this->makeRequest('delete', $method, $args, $timeout);
     }
@@ -125,7 +127,7 @@ class MailChimp
      * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function get($method, $args = array(), $timeout = 10)
+    public function get($method, $args = array(), $timeout = self::TIMEOUT)
     {
         return $this->makeRequest('get', $method, $args, $timeout);
     }
@@ -137,7 +139,7 @@ class MailChimp
      * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function patch($method, $args = array(), $timeout = 10)
+    public function patch($method, $args = array(), $timeout = self::TIMEOUT)
     {
         return $this->makeRequest('patch', $method, $args, $timeout);
     }
@@ -149,7 +151,7 @@ class MailChimp
      * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function post($method, $args = array(), $timeout = 10)
+    public function post($method, $args = array(), $timeout = self::TIMEOUT)
     {
         return $this->makeRequest('post', $method, $args, $timeout);
     }
@@ -161,7 +163,7 @@ class MailChimp
      * @param   int $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
      */
-    public function put($method, $args = array(), $timeout = 10)
+    public function put($method, $args = array(), $timeout = self::TIMEOUT)
     {
         return $this->makeRequest('put', $method, $args, $timeout);
     }
@@ -175,7 +177,7 @@ class MailChimp
      * @return array|false Assoc array of decoded result
      * @throws \Exception
      */
-    private function makeRequest($http_verb, $method, $args = array(), $timeout = 10)
+    private function makeRequest($http_verb, $method, $args = array(), $timeout = self::TIMEOUT)
     {
         if (!function_exists('curl_init') || !function_exists('curl_setopt')) {
             throw new \Exception("cURL support is required, but can't be found.");

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -390,7 +390,7 @@ class MailChimp
             return false;
         }
 
-        if( $response['headers'] && $response['headers']['total_time'] >= $timeout ) {
+        if( $timeout > 0 && $response['headers'] && $response['headers']['total_time'] >= $timeout ) {
             $this->last_error = sprintf('Request timed out after %f seconds.', $response['headers']['total_time'] );
             return false;
         }

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -247,10 +247,10 @@ class MailChimp
         
         $responseContent = curl_exec($ch);
         
+        $response['headers'] = curl_getinfo($ch);
         if ($responseContent === false) {
             $this->last_error = curl_error($ch);
         } else {
-            $response['headers'] = curl_getinfo($ch);
             $headerSize = $response['headers']['header_size'];
             
             $response['httpHeaders'] = $this->getHeadersAsArray(substr($responseContent, 0, $headerSize));

--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -265,7 +265,7 @@ class MailChimp
 
         $formattedResponse = $this->formatResponse($response);
 
-        $this->determineSuccess($response, $formattedResponse);
+        $this->determineSuccess($response, $formattedResponse, $timeout);
 
         return $formattedResponse;
     }
@@ -373,9 +373,10 @@ class MailChimp
      * Check if the response was successful or a failure. If it failed, store the error.
      * @param array $response The response from the curl request
      * @param array|false $formattedResponse The response body payload from the curl request
+     * @param int $timeout The timeout supplied to the curl request.
      * @return bool     If the request was successful
      */
-    private function determineSuccess($response, $formattedResponse)
+    private function determineSuccess($response, $formattedResponse, $timeout)
     {
         $status = $this->findHTTPStatus($response, $formattedResponse);
 
@@ -386,6 +387,11 @@ class MailChimp
 
         if (isset($formattedResponse['detail'])) {
             $this->last_error = sprintf('%d: %s', $formattedResponse['status'], $formattedResponse['detail']);
+            return false;
+        }
+
+        if( $response['headers'] && $response['headers']['total_time'] >= $timeout ) {
+            $this->last_error = sprintf('Request timed out after %f seconds.', $response['headers']['total_time'] );
             return false;
         }
 

--- a/tests/MailChimpTest.php
+++ b/tests/MailChimpTest.php
@@ -73,4 +73,29 @@ class MailChimpTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($MailChimp->success());
     }
 
+    /* This test requires that your test list have:
+     * a) a list
+     * b) enough entries that the curl request will timeout after 1 second.
+     * How many this is may depend on your network connection to the Mailchimp servers.
+     */
+    public function testRequestTimeout()
+    {
+        $MC_API_KEY = getenv('MC_API_KEY');
+
+        if (!$MC_API_KEY) {
+            $this->markTestSkipped('No API key in ENV');
+        }
+
+        $MailChimp = new MailChimp($MC_API_KEY);
+        $result = $MailChimp->get('lists');
+        $list_id = $result['lists'][0]['id'];
+
+        $args = array( 'count' => 1000 );
+        $timeout = 1;
+        $result = $MailChimp->get("lists/$list_id/members", $args, $timeout );
+        $this->assertFalse( $result );
+
+        $error = $MailChimp->getLastError();
+        $this->assertRegExp( '/Request timed out after 1.\d+ seconds/', $error );
+    }
 }


### PR DESCRIPTION
Resolves #144

If the `curl` request times out, return a useful error message.

An example of a timeout on a request with a 1 second timeout: 

Previous behaviour: 
`getLastError()` => `Unknown error, call getLastResponse() to find out what happened.`
But it was still impossible to determine that a timeout had occurred by looking at the contents of getLastResponse() 

New behaviour:
`getLastError()` => `Request timed out after 1.001423 seconds.`
