### PR TITLE
Fixing syntax error on MailChimp->getLastError()

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -96,7 +96,7 @@ class MailChimp
      */
     public function getLastError()
     {
-        return $this->last_error ?: false;
+        return $this->last_error ? $this->last_error : false;
     }
 
     /**


### PR DESCRIPTION
Fixing getLastError() return, using php5.6 on Wordpress v.4.7
![image](https://user-images.githubusercontent.com/12158982/26987813-4cf9b73a-4d23-11e7-90d4-41f6bfecb341.png)
