### PR TITLE
Do not explicitly use HTTP 1.0 for requests

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -236,7 +236,6 @@ class MailChimp
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verify_ssl);
-        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
         curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 


### PR DESCRIPTION
Removing this allows libcurl to use the default `CURL_HTTP_VERSION_2TLS` (for libcurl >= `7.62.0`; otherwise `CURL_HTTP_VERSION_1_1` is used).

Docs: https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html

Closes https://github.com/drewm/mailchimp-api/issues/251