### PR TITLE
WIP: Add function to check if api key was set

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -77,6 +77,13 @@ class MailChimp
         return $this->api_endpoint;
     }
 
+    /**
+     * @return bool A api key was set
+     */
+    public function hasApiKey()
+    {
+        return (bool) $this->api_key;
+    }
 
     /**
      * Convert an email address into a 'subscriber hash' for identifying the subscriber in a method URL

--- a/tests/MailChimpTest.php
+++ b/tests/MailChimpTest.php
@@ -81,6 +81,15 @@ class MailChimpTest extends TestCase
 
         $this->assertTrue($MailChimp->success());
     }
+    
+    public function testHasKey()
+    {
+        $MailChimp = new MailChimp('some-key');
+        $this->assertTrue($MailChimp->hasApiKey());
+
+        $MailChimp = new MailChimp('');
+        $this->assertFalse($MailChimp->hasApiKey());
+    }
 
     /* This test requires that your test list have:
      * a) a list


### PR DESCRIPTION
Add function to check if mailchimp api key was set e.g.:

```php
$mailChimp = new MailChimp(get_env('MAILCHIMP_API_KEY'));

if (!$mailChimp->hasApiKey()) {
     // do nothing when no api key was set
     return;
}

$mailChimp->...
```

most use case if you register MailChimp class in dependency injection container so you avoid to inject also the api key to all services to check if its really needed.