### PR TITLE
Email subscription method with additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ if ($MailChimp->success()) {
 	echo $MailChimp->getLastError();
 }
 ```
+Optionally you can subscribe an email address using additional fields as well, just pass another parameter named `merge_fields` as an array consisting field lists:
+
+```php
+$list_id = 'b1234346';
+
+$result = $MailChimp->post("lists/$list_id/members", [
+				'email_address' => 'davy@example.com',
+				'status'        => 'subscribed',
+				'merge_fields'	=> array('FNAME' =>'john', 'LNAME'=>'Doe')
+			]);
+
+if ($MailChimp->success()) {
+	print_r($result);	
+} else {
+	echo $MailChimp->getLastError();
+}
+```
+
 
 Batch Operations
 ----------------


### PR DESCRIPTION
**Case:** While I was not able to get the function to add an email address to the subscriber along with additional field like `FNAME`, `LNAME` etc. 
Function describes here explain about either single email or adding an additional field with patch request, which requires first to add an email address, followed by getting hash of it and then update with patch method. 
I have gone through the documentation and found its just another parameter, so care to add this in part of the documentation.

**Implemented:** Added additional field name `merge_fields` which accept an array of field lists which can be supplied in addition to the email address in the subscription.
Reference: https://developer.mailchimp.com/documentation/mailchimp/guides/manage-subscribers-with-the-mailchimp-api/
```
{
    "email_address": "urist.mcvankab@freddiesjokes.com",
    "status": "subscribed",
    "merge_fields": {
        "FNAME": "Urist",
        "LNAME": "McVankab"
    }
}
```

PS: No test needed, just small change in the documentation, got me tricky how to add email with additional field once, without adding email once and updating with the patch on another call.