### PR TITLE
Split header lines by `:` instead of `: `

### DIFF
--- a/src/MailChimp.php
+++ b/src/MailChimp.php
@@ -337,7 +337,8 @@ class MailChimp
                 continue;
             }
 
-            list($key, $value) = explode(': ', $line);
+            list($key, $value) = explode(':', $line);
+            $value = ltrim($value);
 
             if ($key == 'Link') {
                 $value = array_merge(


### PR DESCRIPTION
MailChimp's API apparently stopped using a space after the colon in header lines, because I started receiving an error about there not being a value at `1` on the line `list($key, $value) = explode(': ', $line);`. This can be prevented and future-proofed with my change.

Removing the space and adding an `ltrim` to the value correctly splits the header all the time and ensures there's no leading spaces in case MailChimp ever changes back to adding a space.